### PR TITLE
* feat: sugestoes em #63

### DIFF
--- a/AsaasClient.MinimalSample/AsaasClient.MinimalSample.csproj
+++ b/AsaasClient.MinimalSample/AsaasClient.MinimalSample.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.9" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\AsaasClient\AsaasClient.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/AsaasClient.MinimalSample/Program.cs
+++ b/AsaasClient.MinimalSample/Program.cs
@@ -1,0 +1,49 @@
+using AsaasClient;
+using AsaasClient.Core.Response;
+using AsaasClient.Models.Common.Enums;
+using AsaasClient.Models.Customer;
+using AsaasClient.Models.Payment;
+using Microsoft.AspNetCore.Mvc;
+
+var builder = WebApplication.CreateBuilder(args);
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+
+
+// Add services to the container.
+builder.Services.AddAsaas(builder.Configuration);
+
+var app = builder.Build();
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+// Configure the HTTP request pipeline.
+app.MapGet("/pagar", async ([FromServices] IAsaasService asaasService) =>
+{
+
+    ResponseObject<Customer> customerResponse = await asaasService.Customer.Find("cus_13bFHumeyglN");
+
+    if (customerResponse.WasSucessfull())
+    {
+        Customer customer = customerResponse.Data;
+
+        ResponseObject<Payment> paymentResponse = await asaasService.Payment.Create(new CreatePaymentRequest()
+        {
+            CustomerId = customer.Id,
+            BillingType = BillingType.BOLETO,
+            Value = 32.55M,
+            DueDate = DateTime.Parse("12/12/2020")
+        });
+
+        return Results.Ok(paymentResponse);
+    }
+
+    return Results.BadRequest(customerResponse);
+
+})
+    .WithName("pagar")
+    .WithOpenApi(); ;
+
+app.Run();

--- a/AsaasClient.MinimalSample/Properties/launchSettings.json
+++ b/AsaasClient.MinimalSample/Properties/launchSettings.json
@@ -1,0 +1,23 @@
+﻿{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:29922",
+      "sslPort": 0
+    }
+  },
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "http://localhost:5087",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/AsaasClient.MinimalSample/appsettings.Development.json
+++ b/AsaasClient.MinimalSample/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/AsaasClient.MinimalSample/appsettings.json
+++ b/AsaasClient.MinimalSample/appsettings.json
@@ -1,0 +1,13 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*",
+  "ASAAS": {
+    "AccessToken": "$aact_ssssssssssssssssssssss",
+    "BaseUrl": "https://sandbox.asaas.com"
+  }
+}

--- a/AsaasClient.Sample/AsaasClient.Sample.csproj
+++ b/AsaasClient.Sample/AsaasClient.Sample.csproj
@@ -6,6 +6,9 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\AsaasClient\AsaasClient.csproj" />

--- a/AsaasClient.Sample/Program.cs
+++ b/AsaasClient.Sample/Program.cs
@@ -5,6 +5,7 @@ using AsaasClient.Models.Common.Enums;
 using AsaasClient.Models.Customer;
 using AsaasClient.Models.Payment;
 
+
 ApiSettings apiSettings = new ApiSettings("YOUR_ACCESS_TOKEN", AsaasEnvironment.SANDBOX);
 
 AsaasApi asaasApi = new AsaasApi(apiSettings);
@@ -23,3 +24,4 @@ if (customerResponse.WasSucessfull())
         DueDate = DateTime.Parse("12/12/2020")
     });
 }
+

--- a/AsaasClient.sln
+++ b/AsaasClient.sln
@@ -4,7 +4,9 @@ VisualStudioVersion = 17.1.32421.90
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AsaasClient", "AsaasClient\AsaasClient.csproj", "{F67FEE8D-9974-460A-9713-8A450100C5EB}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AsaasClient.Sample", "AsaasClient.Sample\AsaasClient.Sample.csproj", "{3CFF8BB1-D8B5-42D8-B22F-667BAAF8D4D6}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AsaasClient.Sample", "AsaasClient.Sample\AsaasClient.Sample.csproj", "{3CFF8BB1-D8B5-42D8-B22F-667BAAF8D4D6}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AsaasClient.MinimalSample", "AsaasClient.MinimalSample\AsaasClient.MinimalSample.csproj", "{E3AD690E-A1CD-407D-9F8C-F86188A56294}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -20,6 +22,10 @@ Global
 		{3CFF8BB1-D8B5-42D8-B22F-667BAAF8D4D6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3CFF8BB1-D8B5-42D8-B22F-667BAAF8D4D6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3CFF8BB1-D8B5-42D8-B22F-667BAAF8D4D6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E3AD690E-A1CD-407D-9F8C-F86188A56294}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E3AD690E-A1CD-407D-9F8C-F86188A56294}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E3AD690E-A1CD-407D-9F8C-F86188A56294}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E3AD690E-A1CD-407D-9F8C-F86188A56294}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/AsaasClient/AsaasApi.cs
+++ b/AsaasClient/AsaasApi.cs
@@ -4,7 +4,25 @@ using System;
 
 namespace AsaasClient
 {
-    public class AsaasApi
+    public interface IAsaasService
+    {
+        CustomerManager Customer { get; }
+        PaymentManager Payment { get; }
+        InstallmentManager Installment { get; }
+        SubscriptionManager Subscription { get; }
+        FinanceManager Finance { get; }
+        TransferManager Transfer { get; }
+        WalletManager Wallet { get; }
+        WebhookManager Webhook { get; }
+        AsaasAccountManager AsaasAccount { get; }
+        AnticipationManager ReceivableAnticipation { get; }
+        MyAccountManager MyAccount { get; }
+        InvoiceManager Invoice { get; }
+        PaymentDunningManager PaymentDunning { get; }
+        BillPaymentManager BillPayment { get; }
+    }
+
+    public class AsaasApi : IAsaasService
     {
         #region Lazy
         private Lazy<CustomerManager> LazyCustomer { get; }
@@ -40,6 +58,8 @@ namespace AsaasClient
         public BillPaymentManager BillPayment => LazyBillPayment.Value;
         #endregion
 
+
+
         public AsaasApi(ApiSettings apiSettings)
         {
             LazyCustomer = new Lazy<CustomerManager>(() => new CustomerManager(apiSettings), true);
@@ -58,4 +78,5 @@ namespace AsaasClient
             LazyBillPayment = new Lazy<BillPaymentManager>(() => new BillPaymentManager(apiSettings), true);
         }
     }
+
 }

--- a/AsaasClient/AsaasClient.csproj
+++ b/AsaasClient/AsaasClient.csproj
@@ -15,7 +15,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Options" Version="7.0.1" />
+        <PackageReference Include="System.Text.Json" Version="7.0.3" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
     </ItemGroup>
 
 </Project>

--- a/AsaasClient/AsaasDomainDependencyInjection.cs
+++ b/AsaasClient/AsaasDomainDependencyInjection.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using AsaasClient.Core;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace AsaasClient
+{
+    public static class AsaasDomainDependencyInjection
+    {
+        public static IServiceCollection AddAsaas(this IServiceCollection services, IConfiguration configuration, ApiSettings settings = null)
+        {
+            var asaasConfig = configuration.GetSection("ASAAS");
+
+            settings ??= new ApiSettings(asaasConfig["AccessToken"], asaasConfig["BaseUrl"] ?? "https://www.asaas.com");
+
+
+            services
+                .AddSingleton(settings)
+                .AddScoped<IAsaasService, AsaasApi>();
+            
+            return services;
+        }
+
+    }
+}

--- a/AsaasClient/Core/ApiSettings.cs
+++ b/AsaasClient/Core/ApiSettings.cs
@@ -4,14 +4,22 @@ namespace AsaasClient.Core
 {
     public class ApiSettings
     {
-        public string AccessToken { get; }
-        public AsaasEnvironment AsaasEnvironment { get; }
+        public string AccessToken { get; set; }
+        public string BaseUrl { get; set; }
         public TimeSpan TimeOut { get; set; }
 
+        public ApiSettings() { }
         public ApiSettings(string accessToken, AsaasEnvironment asaasEnvironment)
         {
             AccessToken = accessToken;
-            AsaasEnvironment = asaasEnvironment;
+            BaseUrl = asaasEnvironment == AsaasEnvironment.PRODUCTION ? "https://www.asaas.com" : "https://sandbox.asaas.com";
+
+            TimeOut = TimeSpan.FromSeconds(30);
+        }
+        public ApiSettings(string accessToken, string baseUrl)
+        {
+            AccessToken = accessToken;
+            BaseUrl = baseUrl;
             TimeOut = TimeSpan.FromSeconds(30);
         }
     }

--- a/AsaasClient/Core/AsaasEnvironment.cs
+++ b/AsaasClient/Core/AsaasEnvironment.cs
@@ -4,17 +4,4 @@
     {
         SANDBOX, PRODUCTION
     }
-
-    public static class AsaasEnvironmentExtension
-    {
-        public static bool IsProduction(this AsaasEnvironment asaasEnvironment)
-        {
-            return asaasEnvironment == AsaasEnvironment.PRODUCTION;
-        }
-
-        public static bool IsSandbox(this AsaasEnvironment asaasEnvironment)
-        {
-            return asaasEnvironment == AsaasEnvironment.SANDBOX;
-        }
-    }
 }

--- a/AsaasClient/Core/Response/Base/BaseResponse.cs
+++ b/AsaasClient/Core/Response/Base/BaseResponse.cs
@@ -1,7 +1,6 @@
-﻿using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Net;
+using System.Text.Json;
 
 namespace AsaasClient.Core.Response.Base
 {
@@ -24,9 +23,13 @@ namespace AsaasClient.Core.Response.Base
         {
             if (StatusCode != HttpStatusCode.BadRequest) return;
 
-            JObject jObject = JObject.Parse(AsaasResponse);
+            using JsonDocument document = JsonDocument.Parse(AsaasResponse);
+            JsonElement root = document.RootElement;
 
-            Errors = JsonConvert.DeserializeObject<List<Error>>(jObject.GetValue("errors").ToString());
+            if (root.TryGetProperty("errors", out JsonElement errorsElement))
+            {
+                Errors = JsonSerializer.Deserialize<List<Error>>(errorsElement.GetRawText());
+            }
         }
 
         public bool WasSucessfull() => StatusCode == HttpStatusCode.OK;

--- a/AsaasClient/Core/Response/Error.cs
+++ b/AsaasClient/Core/Response/Error.cs
@@ -1,12 +1,13 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text.Json.Serialization;
+
 namespace AsaasClient.Core.Response
 {
     public class Error
     {
-        [JsonProperty(PropertyName = "code")]
+        [JsonPropertyName("code")]
         public string Code { get; internal set; }
 
-        [JsonProperty(PropertyName = "description")]
+        [JsonPropertyName( "description")]
         public string Description { get; internal set; }
     }
 }

--- a/AsaasClient/Core/Response/ResponseList.cs
+++ b/AsaasClient/Core/Response/ResponseList.cs
@@ -1,9 +1,7 @@
 ﻿using AsaasClient.Core.Response.Base;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
-using System;
 using System.Collections.Generic;
 using System.Net;
+using System.Text.Json;
 
 namespace AsaasClient.Core.Response
 {
@@ -23,13 +21,18 @@ namespace AsaasClient.Core.Response
         {
             if (httpStatusCode != HttpStatusCode.OK) return;
 
-            JObject listObject = JObject.Parse(content);
-            
-            HasMore = listObject.GetValue("hasMore").ToObject<bool>();
-            TotalCount = listObject.GetValue("totalCount").ToObject<int>();
-            Limit = listObject.GetValue("limit").ToObject<int>();
-            Offset = listObject.GetValue("offset").ToObject<int>();
-            Data = JsonConvert.DeserializeObject<List<T>>(listObject.GetValue("data").ToString());
+            using JsonDocument document = JsonDocument.Parse(content);
+            JsonElement root = document.RootElement;
+
+            HasMore = root.GetProperty("hasMore").GetBoolean();
+            TotalCount = root.GetProperty("totalCount").GetInt32();
+            Limit = root.GetProperty("limit").GetInt32();
+            Offset = root.GetProperty("offset").GetInt32();
+
+            if (root.TryGetProperty("data", out JsonElement dataElement))
+            {
+                Data = JsonSerializer.Deserialize<List<T>>(dataElement.GetRawText());
+            }
         }
     }
 }

--- a/AsaasClient/Core/Response/ResponseObject.cs
+++ b/AsaasClient/Core/Response/ResponseObject.cs
@@ -1,5 +1,4 @@
 ﻿using AsaasClient.Core.Response.Base;
-using Newtonsoft.Json;
 using System.Net;
 
 namespace AsaasClient.Core.Response
@@ -12,7 +11,7 @@ namespace AsaasClient.Core.Response
         {
             if (httpStatusCode != HttpStatusCode.OK) return;
 
-            Data = JsonConvert.DeserializeObject<T>(content);
+            Data = System.Text.Json.JsonSerializer.Deserialize<T>(content);
         }
     }
 }

--- a/AsaasClient/Models/Anticipation/Anticipation.cs
+++ b/AsaasClient/Models/Anticipation/Anticipation.cs
@@ -1,5 +1,5 @@
 ﻿using AsaasClient.Models.Anticipation.Enums;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 using System;
 
 namespace AsaasClient.Models.Anticipation
@@ -8,10 +8,10 @@ namespace AsaasClient.Models.Anticipation
     {
         public string Id { get; set; }
 
-        [JsonProperty(PropertyName = "installment")]
+        [JsonPropertyName( "installment")]
         public string InstallmentId { get; set; }
 
-        [JsonProperty(PropertyName = "payment")]
+        [JsonPropertyName( "payment")]
         public string PaymentId { get; set; }
 
         public AnticipationStatus Status { get; set; }

--- a/AsaasClient/Models/Anticipation/CreateAnticipationRequest.cs
+++ b/AsaasClient/Models/Anticipation/CreateAnticipationRequest.cs
@@ -1,15 +1,15 @@
 ﻿using AsaasClient.Models.Common;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 using System.Collections.Generic;
 
 namespace AsaasClient.Models.Anticipation
 {
     public class CreateAnticipationRequest
     {
-        [JsonProperty(PropertyName = "installment")]
+        [JsonPropertyName( "installment")]
         public string InstallmentId { get; set; }
 
-        [JsonProperty(PropertyName = "payment")]
+        [JsonPropertyName( "payment")]
         public string PaymentId { get; set; }
 
         public string AgreementSignature { get; set; }

--- a/AsaasClient/Models/Anticipation/SimulateAnticipationRequest.cs
+++ b/AsaasClient/Models/Anticipation/SimulateAnticipationRequest.cs
@@ -1,13 +1,13 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text.Json.Serialization;
 
 namespace AsaasClient.Models.Anticipation
 {
     public class SimulateAnticipationRequest
     {
-        [JsonProperty(PropertyName = "installment")]
+        [JsonPropertyName( "installment")]
         public string InstallmentId { get; set; }
 
-        [JsonProperty(PropertyName = "payment")]
+        [JsonPropertyName( "payment")]
         public string PaymentId { get; set; }
     }
 }

--- a/AsaasClient/Models/Anticipation/SimulatedAnticipation.cs
+++ b/AsaasClient/Models/Anticipation/SimulatedAnticipation.cs
@@ -1,14 +1,14 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text.Json.Serialization;
 using System;
 
 namespace AsaasClient.Models.Anticipation
 {
     public class SimulatedAnticipation
     {
-        [JsonProperty(PropertyName = "installment")]
+        [JsonPropertyName( "installment")]
         public string InstallmentId { get; set; }
 
-        [JsonProperty(PropertyName = "payment")]
+        [JsonPropertyName( "payment")]
         public string PaymentId { get; set; }
 
         public DateTime AnticipationDate { get; set; }

--- a/AsaasClient/Models/Common/CreditCard.cs
+++ b/AsaasClient/Models/Common/CreditCard.cs
@@ -1,16 +1,16 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text.Json.Serialization;
 
 namespace AsaasClient.Models.Common
 {
     public class CreditCard
     {
-        [JsonProperty(PropertyName = "creditCardNumber")]
+        [JsonPropertyName( "creditCardNumber")]
         public string Number { get; set; }
 
-        [JsonProperty(PropertyName = "creditCardBrand")]
+        [JsonPropertyName( "creditCardBrand")]
         public string Brand { get; set; }
 
-        [JsonProperty(PropertyName = "creditCardToken")]
+        [JsonPropertyName( "creditCardToken")]
         public string Token { get; set; }
     }
 }

--- a/AsaasClient/Models/Customer/Customer.cs
+++ b/AsaasClient/Models/Customer/Customer.cs
@@ -1,5 +1,5 @@
 ﻿using AsaasClient.Models.Common.Enums;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 using System;
 
 namespace AsaasClient.Models.Customer
@@ -42,7 +42,7 @@ namespace AsaasClient.Models.Customer
 
         public bool Deleted { get; set; }
 
-        [JsonProperty(PropertyName = "city")]
+        [JsonPropertyName( "city")]
         public long? CityId { get; set; }
 
         public string State { get; set; }

--- a/AsaasClient/Models/Installment/Installment.cs
+++ b/AsaasClient/Models/Installment/Installment.cs
@@ -1,5 +1,5 @@
 ﻿using AsaasClient.Models.Common.Enums;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 using System;
 
 namespace AsaasClient.Models.Installment
@@ -22,7 +22,7 @@ namespace AsaasClient.Models.Installment
 
         public DateTime ExpirationDay { get; set; }
 
-        [JsonProperty(PropertyName = "customer")]
+        [JsonPropertyName( "customer")]
         public string CustomerId { get; set; }
 
         public bool Deleted { get; set; }

--- a/AsaasClient/Models/Invoice/CreateInvoiceRequest.cs
+++ b/AsaasClient/Models/Invoice/CreateInvoiceRequest.cs
@@ -1,18 +1,18 @@
 ﻿using AsaasClient.Models.Common;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 using System;
 
 namespace AsaasClient.Models.Invoice
 {
     public class CreateInvoiceRequest
     {
-        [JsonProperty(PropertyName = "payment")]
+        [JsonPropertyName( "payment")]
         public string PaymentId { get; set; }
 
-        [JsonProperty(PropertyName = "installment")]
+        [JsonPropertyName( "installment")]
         public string InstallmentId { get; set; }
 
-        [JsonProperty(PropertyName = "customer")]
+        [JsonPropertyName( "customer")]
         public string CustomerId { get; set; }
 
         public string ServiceDescription { get; set; }

--- a/AsaasClient/Models/Invoice/Invoice.cs
+++ b/AsaasClient/Models/Invoice/Invoice.cs
@@ -1,6 +1,6 @@
 ﻿using AsaasClient.Models.Common;
 using AsaasClient.Models.Invoice.Enums;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 using System;
 
 namespace AsaasClient.Models.Invoice
@@ -11,13 +11,13 @@ namespace AsaasClient.Models.Invoice
 
         public InvoiceStatus Status { get; set; }
 
-        [JsonProperty(PropertyName = "customer")]
+        [JsonPropertyName( "customer")]
         public string CustomerId { get; set; }
 
-        [JsonProperty(PropertyName = "payment")]
+        [JsonPropertyName( "payment")]
         public string PaymentId { get; set; }
 
-        [JsonProperty(PropertyName = "installment")]
+        [JsonPropertyName( "installment")]
         public string InstallmentId { get; set; }
 
         public string Type { get; set; }

--- a/AsaasClient/Models/Payment/BankSlipCode.cs
+++ b/AsaasClient/Models/Payment/BankSlipCode.cs
@@ -1,16 +1,16 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text.Json.Serialization;
 
 namespace AsaasClient.Models.Payment
 {
     public class BankSlipCode
     {
-        [JsonProperty(PropertyName = "identificationField")]
+        [JsonPropertyName( "identificationField")]
         public string IdentificationField { get; set; }
 
-        [JsonProperty(PropertyName = "nossoNumero")]
+        [JsonPropertyName( "nossoNumero")]
         public string NossoNumero { get; set; }
 
-        [JsonProperty(PropertyName = "barCode")]
+        [JsonPropertyName( "barCode")]
         public string BarCode { get; set; }
     }
 }

--- a/AsaasClient/Models/Payment/CreatePaymentRequest.cs
+++ b/AsaasClient/Models/Payment/CreatePaymentRequest.cs
@@ -1,6 +1,6 @@
 ﻿using AsaasClient.Models.Common;
 using AsaasClient.Models.Common.Enums;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 using System;
 using System.Collections.Generic;
 
@@ -8,7 +8,7 @@ namespace AsaasClient.Models.Payment
 {
     public class CreatePaymentRequest
     {
-        [JsonProperty(PropertyName = "customer")]
+        [JsonPropertyName( "customer")]
         public string CustomerId { get; set; }
 
         public BillingType BillingType { get; set; }

--- a/AsaasClient/Models/Payment/Payment.cs
+++ b/AsaasClient/Models/Payment/Payment.cs
@@ -1,7 +1,7 @@
 ﻿using AsaasClient.Models.Common;
 using AsaasClient.Models.Common.Enums;
 using AsaasClient.Models.Payment.Enums;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 using System;
 using System.Collections.Generic;
 
@@ -13,13 +13,13 @@ namespace AsaasClient.Models.Payment
 
         public DateTime DateCreated { get; set; }
 
-        [JsonProperty(PropertyName = "customer")]
+        [JsonPropertyName( "customer")]
         public string CustomerId { get; set; }
 
-        [JsonProperty(PropertyName = "subscription")]
+        [JsonPropertyName( "subscription")]
         public string SubscriptionId { get; set; }
 
-        [JsonProperty(PropertyName = "installment")]
+        [JsonPropertyName( "installment")]
         public string InstallmentId { get; set; }
 
         public DateTime DueDate { get; set; }

--- a/AsaasClient/Models/Payment/PixQrCode.cs
+++ b/AsaasClient/Models/Payment/PixQrCode.cs
@@ -1,17 +1,17 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text.Json.Serialization;
 using System;
 
 namespace AsaasClient.Models.Payment
 {
     public class PixQRCode
     {
-        [JsonProperty(PropertyName = "encodedImage")]
+        [JsonPropertyName( "encodedImage")]
         public string EncodedImage { get; set; }
 
-        [JsonProperty(PropertyName = "payload")]
+        [JsonPropertyName( "payload")]
         public string Payload { get; set; }
 
-        [JsonProperty(PropertyName = "expirationDate")]
+        [JsonPropertyName( "expirationDate")]
         public DateTime ExpirationDate { get; set; }
     }
 }

--- a/AsaasClient/Models/Payment/UpdatePaymentRequest.cs
+++ b/AsaasClient/Models/Payment/UpdatePaymentRequest.cs
@@ -1,12 +1,12 @@
 ﻿using AsaasClient.Models.Common;
 using AsaasClient.Models.Common.Enums;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 using System;
 
 namespace AsaasClient.Models.Payment
 {
     public class UpdatePaymentRequest {
-        [JsonProperty(PropertyName = "customer")]
+        [JsonPropertyName( "customer")]
         public string CustomerId { get; set; }
 
         public BillingType? BillingType { get; set; }

--- a/AsaasClient/Models/PaymentDunning/CreatePaymentDunningRequest.cs
+++ b/AsaasClient/Models/PaymentDunning/CreatePaymentDunningRequest.cs
@@ -1,13 +1,13 @@
 ﻿using AsaasClient.Models.Common;
 using AsaasClient.Models.PaymentDunning.Enums;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 using System.Collections.Generic;
 
 namespace AsaasClient.Models.PaymentDunning
 {
     public class CreatePaymentDunningRequest {
 
-        [JsonProperty(PropertyName = "payment")]
+        [JsonPropertyName( "payment")]
         public string PaymentId { get; set; }
 
         public PaymentDunningType Type { get; set; }

--- a/AsaasClient/Models/PaymentDunning/PaymentDunning.cs
+++ b/AsaasClient/Models/PaymentDunning/PaymentDunning.cs
@@ -1,5 +1,5 @@
 ﻿using AsaasClient.Models.PaymentDunning.Enums;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 using System;
 
 namespace AsaasClient.Models.PaymentDunning
@@ -14,7 +14,7 @@ namespace AsaasClient.Models.PaymentDunning
 
         public PaymentDunningType Type { get; set; }
 
-        [JsonProperty(PropertyName = "payment")]
+        [JsonPropertyName( "payment")]
         public string PaymentId { get; set; }
 
         public DateTime RequestDate { get; set; }

--- a/AsaasClient/Models/PaymentDunning/PaymentDunningPaymentAvailable.cs
+++ b/AsaasClient/Models/PaymentDunning/PaymentDunningPaymentAvailable.cs
@@ -1,16 +1,16 @@
 ﻿using AsaasClient.Models.Common.Enums;
 using AsaasClient.Models.Payment.Enums;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 using System;
 
 namespace AsaasClient.Models.PaymentDunning
 {
     public class PaymentDunningPaymentAvailable
     {
-        [JsonProperty(PropertyName = "payment")]
+        [JsonPropertyName( "payment")]
         public string PaymentId { get; set; }
 
-        [JsonProperty(PropertyName = "customer")]
+        [JsonPropertyName( "customer")]
         public string CustomerId { get; set; }
 
         public decimal Value { get; set; }

--- a/AsaasClient/Models/PaymentDunning/SimulatePaymentDunningRequest.cs
+++ b/AsaasClient/Models/PaymentDunning/SimulatePaymentDunningRequest.cs
@@ -1,10 +1,10 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text.Json.Serialization;
 
 namespace AsaasClient.Models.PaymentDunning
 {
     public class SimulatePaymentDunningRequest
     {
-        [JsonProperty(PropertyName = "payment")]
+        [JsonPropertyName( "payment")]
         public string PaymentId { get; set; }
     }
 }

--- a/AsaasClient/Models/PaymentDunning/SimulatedPaymentDunning.cs
+++ b/AsaasClient/Models/PaymentDunning/SimulatedPaymentDunning.cs
@@ -1,9 +1,9 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text.Json.Serialization;
 
 namespace AsaasClient.Models.PaymentDunning
 {
     public class SimulatedPaymentDunning {
-        [JsonProperty(PropertyName = "payment")]
+        [JsonPropertyName( "payment")]
         public string PaymentId { get; set; }
 
         public decimal Value { get; set; }

--- a/AsaasClient/Models/Subscription/CreateSubscriptionRequest.cs
+++ b/AsaasClient/Models/Subscription/CreateSubscriptionRequest.cs
@@ -1,13 +1,13 @@
 ﻿using AsaasClient.Models.Common;
 using AsaasClient.Models.Common.Enums;
 using AsaasClient.Models.Subscription.Enums;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 using System;
 
 namespace AsaasClient.Models.Subscription
 {
     public class CreateSubscriptionRequest {
-        [JsonProperty(PropertyName = "customer")]
+        [JsonPropertyName( "customer")]
         public string CustomerId { get; set; }
 
         public BillingType BillingType { get; set; }

--- a/AsaasClient/Models/Subscription/Subscription.cs
+++ b/AsaasClient/Models/Subscription/Subscription.cs
@@ -1,7 +1,7 @@
 ﻿using AsaasClient.Models.Common;
 using AsaasClient.Models.Common.Enums;
 using AsaasClient.Models.Subscription.Enums;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 using System;
 
 namespace AsaasClient.Models.Subscription
@@ -11,7 +11,7 @@ namespace AsaasClient.Models.Subscription
 
         public DateTime DateCreated { get; set; }
 
-        [JsonProperty(PropertyName = "customer")]
+        [JsonPropertyName( "customer")]
         public string CustomerId { get; set; }
 
         public BillingType BillingType { get; set; }

--- a/README.md
+++ b/README.md
@@ -42,6 +42,56 @@ if (createdCustomerResponse.WasSucessfull())
 }
 ```
 
+### ASP.NET 
+
+To use the Asaas SDK in your ASP.NET application, follow the steps below
+
+1. Modify the `appsettings.json` file to include Asaas settings:
+
+```json
+"ASAAS": {
+    "AccessToken": "$aact_ssssssssssssssssssssss", // Replace with your AccessToken
+    "BaseUrl": "https://sandbox.asaas.com" // Base URL of the Asaas environment (can be sandbox or production) --> Production: https://asaas.com
+}
+```
+
+2. Add the Asaas service in your service configuration method:
+
+```csharp
+
+var builder = WebApplication.CreateBuilder(args);
+// Add Assass Service
+builder.Services.AddAsaas(builder.Configuration);
+
+var app = builder.Build();
+
+app.MapGet("/pay", async ([FromServices] IAsaasService asaasService) =>
+{
+
+    ResponseObject<Customer> customerResponse = await asaasService.Customer.Find("cus_13bFHumeyglN");
+
+    if (customerResponse.WasSucessfull())
+    {
+        Customer customer = customerResponse.Data;
+
+        ResponseObject<Payment> paymentResponse = await asaasService.Payment.Create(new CreatePaymentRequest()
+        {
+            CustomerId = customer.Id,
+            BillingType = BillingType.BOLETO,
+            Value = 32.55M,
+            DueDate = DateTime.Parse("12/12/2020")
+        });
+
+        return Results.Ok(paymentResponse);
+    }
+
+    return Results.BadRequest(customerResponse);
+
+})
+
+app.Run();
+```
+
 ## Installation
 
 ### [NuGet](https://www.nuget.org/packages/Asaas.SDK/)


### PR DESCRIPTION
* Habilitando Injecao de dependencia
* HttpClient estatico
* Substituicao do Newtonsoft.Json

Adicao de exemplo em MinimalApi

Não adicionei o uso do IHttpClientFactory. Embora fosse a melhor opção iria gerar Break Change com as versões anteriores. O HttpClient static já deve ser suficiente segundo as docs da Microsoft.

Ps: Se vocês tiverem casos de testes e puderem rodar antes. A troca do Newtonsoft para o System.Text.Json requer cuidado.

Todas as dependencias adicionadas mantem a compatibilidade com o netstandard 2.0.